### PR TITLE
Limit employees in Request Manager

### DIFF
--- a/KioskApplication/src/main/java/controller/RequestManagerController.java
+++ b/KioskApplication/src/main/java/controller/RequestManagerController.java
@@ -57,6 +57,56 @@ public class RequestManagerController extends ScreenController {
     }
 
     @FXML
+    public void setup(){
+        RequestType employeeType = l.getServiceAbility(l.getUsername());
+        if(l.getCurrentPermission().equals(KioskPermission.EMPLOYEE) && !employeeType.equals(RequestType.GENERAL)){
+            foodFilter.setSelected(false);
+            foodFilter.setDisable(true);
+            janitorFilter.setSelected(false);
+            janitorFilter.setDisable(true);
+            securityFilter.setSelected(false);
+            securityFilter.setDisable(true);
+            interpreterFilter.setSelected(false);
+            interpreterFilter.setDisable(true);
+            maintenanceFilter.setSelected(false);
+            maintenanceFilter.setDisable(true);
+            itFilter.setSelected(false);
+            itFilter.setDisable(true);
+            transportationFilter.setSelected(false);
+            transportationFilter.setDisable(true);
+            switch (employeeType){
+                case FOOD:
+                    foodFilter.setSelected(true);
+                    break;
+                case SECURITY:
+                    securityFilter.setSelected(true);
+                    break;
+                case INTERPRETER:
+                    interpreterFilter.setSelected(true);
+                    break;
+                case JANITOR:
+                    janitorFilter.setSelected(true);
+                    break;
+            }
+        }else{
+            foodFilter.setSelected(true);
+            foodFilter.setDisable(false);
+            janitorFilter.setSelected(true);
+            janitorFilter.setDisable(false);
+            securityFilter.setSelected(true);
+            securityFilter.setDisable(false);
+            interpreterFilter.setSelected(true);
+            interpreterFilter.setDisable(false);
+            maintenanceFilter.setSelected(true);
+            maintenanceFilter.setDisable(false);
+            itFilter.setSelected(true);
+            itFilter.setDisable(false);
+            transportationFilter.setSelected(true);
+            transportationFilter.setDisable(false);
+        }
+    }
+
+    @FXML
     void viewRequests() throws IOException {
         System.out.println("request Manager Pressed\n");
         getParent().switchToScreen(ApplicationScreen.REQUEST_MANAGER);
@@ -64,18 +114,21 @@ public class RequestManagerController extends ScreenController {
 
     @FXML
     void newRequests(){
+        setup();
         LinkedList<Request> allRequests = filterRequests();
         showRequests(RequestProgressStatus.TO_DO, "Assign", allRequests);
     }
 
     @FXML
     void inProgressRequests(){
+        setup();
         LinkedList<Request> allRequests = filterRequests();
         showRequests(RequestProgressStatus.IN_PROGRESS, "Complete", allRequests);
     }
 
     @FXML
     void doneRequests(){
+        setup();
         LinkedList<Request> allRequests = filterRequests();
         showRequests(RequestProgressStatus.DONE, "Delete", allRequests);
     }

--- a/KioskApplication/src/main/java/entity/LoginEntity.java
+++ b/KioskApplication/src/main/java/entity/LoginEntity.java
@@ -167,6 +167,15 @@ public class LoginEntity {
         return false;
     }
 
+    public RequestType getServiceAbility(String userName) {
+        if(logins.get(userName).getPermission().equals(KioskPermission.EMPLOYEE)){
+            Employee employee = logins.get(userName);
+            return employee.getServiceAbility();
+        }else{
+            return RequestType.GENERAL;
+        }
+    }
+
     // Method for users to update only their passwords, and no one else's
     public boolean updatePassword(String newPassword, String oldPassword){
         boolean updated = false;


### PR DESCRIPTION
When an employee selects one of the side buttons, they are limited to view only the requests that fall under their serviceAbility. Just a small change to the request manager controller